### PR TITLE
Fix incorrect requirement to use small caps.

### DIFF
--- a/docs/data/use_of_oai_pmh.rst
+++ b/docs/data/use_of_oai_pmh.rst
@@ -23,7 +23,7 @@ OpenAIRE ``openaire_data``
 ======== =================
 
 .. note::
-   A harvester only uses the **setSpec** value to perform selective harvesting. The letters of the setSpec must be in small caps.
+   A harvester only uses the **setSpec** value to perform selective harvesting. The letters of the setSpec must be in lowercase.
 
 .. _d:setcontent:
 

--- a/docs/literature/use_of_oai_pmh.rst
+++ b/docs/literature/use_of_oai_pmh.rst
@@ -23,7 +23,7 @@ OpenAIRE ``openaire``
 ======== ============
 
 .. note::
-   A harvester only uses the **setSpec** value to perform selective harvesting. The letters of the setSpec must be in small caps.
+   A harvester only uses the **setSpec** value to perform selective harvesting. The letters of the setSpec must be in lowercase.
 
 Set content
 ~~~~~~~~~~~


### PR DESCRIPTION
The term "small caps" refers to something specific.  Per the [Wikipedia article](https://en.wikipedia.org/wiki/Small_caps)

> In typography, small caps (short for small capitals) are characters
> typeset with glyphs that resemble uppercase letters but reduced in
> height and weight close to the surrounding lowercase letters or text
> figures.

Given OAI-PMH v2.0 mandates the use of UTF-8, using small caps is actually possible(!)

However, from the example, it's pretty clear that this is _not_ what is meant.

Instead, the intention is that the letters are [minuscule or lowercase](https://en.wikipedia.org/wiki/Letter_case#Minuscule), which (for a variety of reasons) is much more plausable and realistic requirement.